### PR TITLE
libstagefright: playback of flac files with a sampling rate of 192kHz

### DIFF
--- a/media/libstagefright/FLACExtractor.cpp
+++ b/media/libstagefright/FLACExtractor.cpp
@@ -585,6 +585,7 @@ status_t FLACParser::init()
         case 48000:
         case 88200:
         case 96000:
+        case 192000:
             break;
         default:
             ALOGE("unsupported sample rate %u", getSampleRate());


### PR DESCRIPTION
Fixed playback of flac files with a sampling rate of 192kHz